### PR TITLE
Made it so CommandProcessingDriver does something similar to what the…

### DIFF
--- a/CommandProcessing.cpp
+++ b/CommandProcessing.cpp
@@ -105,7 +105,15 @@ bool has_suffix(const std::string &str, const std::string &suffix)
            str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
-// Check if the valid command can be used in the current game state
+/** 
+ * Check command is valid in current game state.
+ * Doesn't check if map in "loadmap <map>" is valid, as logic for validating a map file should handle that.
+ * Saves effect rather than cout'ing as logic in most game loops involves printing the effect of a command.
+ * 
+ * @param command The command to validate
+ * @param currentGameState Current state of the game
+ * @return If command is valid or not in the current state
+ * */
 bool CommandProcessor::validate(Command *command, GameStates currentGameState)
 {
     stringstream commandStream(command->getCommand());
@@ -121,7 +129,6 @@ bool CommandProcessor::validate(Command *command, GameStates currentGameState)
     if (segmentList.size() > 2)
     {
         command->saveEffect(command->getCommand() + " has too many parameters");
-        cout << command->getCommand() + " has too many parameters " << endl;
 
         return false;
     }
@@ -132,7 +139,7 @@ bool CommandProcessor::validate(Command *command, GameStates currentGameState)
     if (!CommandStrings::isStringCommandString(commandString))
     {
         command->saveEffect(commandString + " is not a valid command string");
-        cout << "Invalid command." << endl;
+        
         return false;
     }
 
@@ -140,14 +147,12 @@ bool CommandProcessor::validate(Command *command, GameStates currentGameState)
     if ((commandString == CommandStrings::loadMap || commandString == CommandStrings::addPlayer) && segmentList.size() != 2)
     {
         command->saveEffect(commandString + " must have only one valid parameter, separated by a white space");
-        cout << commandString + " must have only one valid parameter, separated by a white space" << endl;
 
         return false;
     }
     if (commandString != CommandStrings::loadMap && commandString != CommandStrings::addPlayer && segmentList.size() != 1)
     {
         command->saveEffect(commandString + " cannot have any parameters");
-        cout << commandString + " cannot have any parameters" << endl;
 
         return false;
     }
@@ -273,9 +278,6 @@ FileCommandProcessorAdapter::~FileCommandProcessorAdapter()
 
 void FileCommandProcessorAdapter::readCommand()
 {
-
-    // this->saveCommand("Opening file " + filePath);
-
     ifstream input(filePath);
 
     cout << filePath << endl;

--- a/CommandProcessingDriver.cpp
+++ b/CommandProcessingDriver.cpp
@@ -44,25 +44,51 @@ void testCommandProcessor(int argc, char **argv)
     }
 
     GameEngine *game = new GameEngine();
-    processor->getCommand(); // processor is now perfectly using polymorphism
-    vector<Command *> commands = processor->getCommandsList();
+    game->displayCurrentGameState();
+    
+    bool gameInProgress = true;
 
-    for (Command *i : commands)
+    int lastIndex = -1;
+
+    while (gameInProgress)
     {
-        if (i->getCommand().find("Opening") == std::string::npos)
-        {
-            cout << "========================================" << endl;
-            cout << "Command: " << i->getCommand() << endl;
-            cout << *game << endl; // print the state of the game
-            if (processor->validate(i, game->getCurrentGameState()))
-            {
-                cout << "Command is VALID in the current state" << endl;
-                game->changeStateFromCommand(i->getCommand()); // if the command is valid, change state of game
+        processor->getCommand();
+
+        vector<Command *> commands = processor->getCommandsList();
+
+        for (int i = lastIndex == -1 ? 0 : lastIndex; i < commands.size(); i++)
+        {   
+            if (processor->validate(commands[i], game->getCurrentGameState()))
+            {   
+                game->changeStateFromCommand(commands[i]);
             }
-            else
-            {
-                cout << "Command is INVALID in the current state" << endl;
+
+            cout << commands[i]->getEffect() << endl;
+
+            if (commands[i]->getCommand() == CommandStrings::quit) {
+                gameInProgress = false;
+                game->displayFarewellMessage();
+                continue;
+            }
+
+            game->displayCurrentGameState();
+
+            if (game->getCurrentGameState() == ASSIGNREINFORCEMENTS) {
+                cout << "Simulating a Warzone game..." 
+                    << endl 
+                    << "Congratulations! All signs point to your victory, oh glorious one." 
+                    << endl;
+
+                game->setGameState(WIN);
+
+                game->displayCurrentGameState();
             }
         }
-    }
+
+        if (!filePath.empty()) {
+            gameInProgress= false;
+        }
+
+        lastIndex = commands.size();
+    }    
 }

--- a/GameEngine.cpp
+++ b/GameEngine.cpp
@@ -176,12 +176,14 @@ bool GameEngine::hasGameBeenEnded(string command)
  * Parses a command string to its numeric/enum representation and changes the game state based both the numeric and string
  * value of the user input.
  *
- * @param commandString The user input command string from the console
+ * @param command The input command
  * @returns Whether or not a state change has taken place. If a change has not occured, it is because the state change
  * was not a valid one.
  */
-bool GameEngine::changeStateFromCommand(string commandString)
+bool GameEngine::changeStateFromCommand(Command *command)
 {
+    string commandString = command->getCommand();
+
     if (commandString == CommandStrings::quit)
     {
         return false;
@@ -189,22 +191,27 @@ bool GameEngine::changeStateFromCommand(string commandString)
 
     if (commandString.find("loadmap") != std::string::npos)
     {
+        command->saveEffect("Successfully loaded map file. State changed to MAPLOADED ");
         this->currentGameState = MAPLOADED;
     }
     else if (commandString == CommandStrings::validateMap)
     {
+        command->saveEffect("Map was successfully validated. State changed to MAPVALIDATED ");
         this->currentGameState = MAPVALIDATED;
     }
     else if (commandString.find("addplayer") != std::string::npos)
     {
+        command->saveEffect("Player  was added successfully ");
         this->currentGameState = PLAYERSADDED;
     }
     else if (commandString == CommandStrings::gameStart)
     {
+        command->saveEffect("Map added and validated successfully. All players added. Transitioned from start up phase into main game loop! ");
         this->currentGameState = ASSIGNREINFORCEMENTS;
     }
     else if (commandString == CommandStrings::replay)
     {
+        command->saveEffect("Restarting game");
         this->currentGameState = START;
     }
     else
@@ -347,7 +354,7 @@ void GameEngine::addPlayer(Command *command)
     playerList.push_back(player);
 
     setGameState(PLAYERSADDED);
-    
+
     command->saveEffect("Player " + playerName + " was added successfully ");
 }
 
@@ -532,11 +539,11 @@ void GameEngine::startNewGame()
             continue;
         }
 
-        if (!changeStateFromCommand(inputCommand))
-        {
-            cout << "Invalid state transition!" << endl;
-        }
-        else if (hasPlayerWon())
+        // if (!changeStateFromCommand(inputCommand))
+        // {
+        //     cout << "Invalid state transition!" << endl;
+        // }
+        if (hasPlayerWon())
         { // In "else if" so displays only once if user decides to input jargin after claiming victory
             displayVictoryMessage();
         }

--- a/GameEngine.h
+++ b/GameEngine.h
@@ -27,9 +27,7 @@ private:
     vector<Player *> playerList;
 
     void displayWelcomeMessage();
-    void displayFarewellMessage();
     void displayVictoryMessage();
-    void displayCurrentGameState();
 
     string getUserInput();
 
@@ -53,24 +51,23 @@ public:
     GameEngine(const GameEngine &);
 
     GameEngine &operator=(const GameEngine &engine);
-    bool changeStateFromCommand(string commandString);
+    bool changeStateFromCommand(Command *command);
 
     // friend ostream& operator << (ostream&, const GameEngine&);
 
     void startNewGame();
 
     void startupPhase();
-
     void mainGameLoop();
-
     void reinforcementPhase();
-
     void issueOrdersPhase();
-
     void executeOrdersPhase();
 
     GameStates getCurrentGameState();
     void setGameState(GameStates newState);
+    void displayCurrentGameState();
+    
+    void displayFarewellMessage();
 };
 
 extern GameEngine* ge;


### PR DESCRIPTION
… old GameEngineDriver test did, going through game states, except since there are no more commands for main game loop it will skip to WIN after gamestart. Saved the effect of commands in chanegStateFromCommand in GameEngine to make it easier to get the correct effect